### PR TITLE
Potential fix for code scanning alert no. 1: Multiplication result converted to larger type

### DIFF
--- a/src/_ftbitmap.c
+++ b/src/_ftbitmap.c
@@ -520,7 +520,7 @@
         if ( old_target_pitch < 0 )
           old_target_pitch = -old_target_pitch;
 
-        old_size = target->rows * (FT_UInt)old_target_pitch;
+        old_size = (FT_ULong)target->rows * (FT_UInt)old_target_pitch;
 
         target->pixel_mode = FT_PIXEL_MODE_GRAY;
         target->rows       = source->rows;


### PR DESCRIPTION
Potential fix for [https://github.com/dawidg81/classichate/security/code-scanning/1](https://github.com/dawidg81/classichate/security/code-scanning/1)

To fix the problem, the multiplication should be performed in the larger type (`FT_ULong`) to avoid overflow. This can be done by casting one of the operands to `FT_ULong` before the multiplication, ensuring that the multiplication is done in `FT_ULong` arithmetic. Specifically, in the line `old_size = target->rows * (FT_UInt)old_target_pitch;`, cast `target->rows` to `FT_ULong` before multiplying. Only this line needs to be changed in the file `src/_ftbitmap.c`. No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
