### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in content resolution

### DIFF
--- a/android/app/src/main/java/com/classicube/MainActivity.java
+++ b/android/app/src/main/java/com/classicube/MainActivity.java
@@ -843,6 +843,10 @@ public class MainActivity extends Activity
 	}
 
 	void saveTempToContent(Uri uri, String path) throws IOException {
+		// Validate that the URI is a content URI and not a file URI or other scheme
+		if (uri == null || !"content".equals(uri.getScheme())) {
+			throw new SecurityException("Invalid URI scheme: only content:// URIs are allowed");
+		}
 		File file = new File(getGameDataDirectory() + "/" + path);
 		OutputStream output = null;
 		InputStream input   = null;


### PR DESCRIPTION
Potential fix for [https://github.com/dawidg81/classichate/security/code-scanning/2](https://github.com/dawidg81/classichate/security/code-scanning/2)

To fix this issue, we need to validate the `Uri` before using it with `getContentResolver().openOutputStream(uri)`. The best approach is to ensure that the `Uri` uses the `content://` scheme (not `file://` or others), and optionally, to restrict the authority to a known set (e.g., system file providers). At a minimum, we should reject any `Uri` with a `file://` scheme or that points to sensitive directories (such as `/data/`). This validation should be performed in `saveTempToContent` before opening the output stream. If the `Uri` fails validation, the method should throw an exception or otherwise abort the operation.

**Required changes:**
- In `saveTempToContent(Uri uri, String path)`, add a check to ensure `uri.getScheme().equals("content")`.
- Optionally, check that the authority is not null and is in an allowlist (e.g., `com.android.externalstorage.documents`, `com.android.providers.downloads.documents`, etc.).
- If the check fails, throw a `SecurityException` or return early.
- No new methods are needed, but a helper method for validation could be added for clarity.
- No new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
