### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in content resolution

### DIFF
--- a/android/app/src/main/java/com/classicube/MainActivity.java
+++ b/android/app/src/main/java/com/classicube/MainActivity.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
@@ -883,6 +885,15 @@ public class MainActivity extends Activity
 		//File file = new File(getExternalFilesDir(null), folder + "/" + name);
 		File file = new File(getGameDataDirectory() + "/" + folder + "/" + name);
 		file.getParentFile().mkdirs();
+
+		// Validate the URI to prevent access to private directories
+		String path = uri.getPath();
+		if (path != null) {
+			Path normalized = FileSystems.getDefault().getPath(path).normalize();
+			if (normalized.startsWith("/data")) {
+				throw new SecurityException("Access to private directories is not allowed");
+			}
+		}
 
 		OutputStream output = null;
 		InputStream input   = null;


### PR DESCRIPTION
Potential fix for [https://github.com/dawidg81/classichate/security/code-scanning/3](https://github.com/dawidg81/classichate/security/code-scanning/3)

To fix the problem, we need to validate the externally-provided URI before using it in a content resolution operation. Specifically, before calling `getContentResolver().openInputStream(uri)` in `saveContentToTemp`, we should ensure that the URI does not reference private directories (such as `/data/`), and ideally, only allow URIs from trusted content providers. The best way to do this is to normalize the path from the URI and check that it does not start with `/data` or any other sensitive directory. If the URI is not valid, we should throw a security exception or otherwise abort the operation.

The changes should be made in the `saveContentToTemp` method in `android/app/src/main/java/com/classicube/MainActivity.java`, specifically before the call to `getContentResolver().openInputStream(uri)` (line 892). We will need to extract the path from the URI, normalize it, and check for forbidden prefixes. We may need to import `java.nio.file.FileSystems` and `java.nio.file.Path` for normalization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
