### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/android/app/src/main/java/com/classicube/MainActivity.java
+++ b/android/app/src/main/java/com/classicube/MainActivity.java
@@ -880,6 +880,10 @@ public class MainActivity extends Activity
 	}
 
 	String saveContentToTemp(Uri uri, String folder, String name) throws IOException {
+		// Validate that the file name does not contain path traversal or separators
+		if (name == null || name.contains("..") || name.contains("/") || name.contains("\\")) {
+			throw new IllegalArgumentException("Invalid file name");
+		}
 		//File file = new File(getExternalFilesDir(null), folder + "/" + name);
 		File file = new File(getGameDataDirectory() + "/" + folder + "/" + name);
 		file.getParentFile().mkdirs();


### PR DESCRIPTION
Potential fix for [https://github.com/dawidg81/classichate/security/code-scanning/5](https://github.com/dawidg81/classichate/security/code-scanning/5)

To fix this issue, we need to ensure that the `name` parameter used in `saveContentToTemp` (and any similar file operations) cannot contain path traversal sequences, absolute paths, or path separators. The best way to do this is to validate the `name` string before using it to construct a file path. Specifically, we should check that `name` does not contain any of the following:

- ".." (parent directory traversal)
- "/" (Unix path separator)
- "\\" (Windows path separator)

If any of these are present, we should reject the input (e.g., throw an exception or return an error). This validation should be performed at the start of `saveContentToTemp`, before the file is constructed. Optionally, we could also restrict the allowed characters to a safe subset (e.g., alphanumeric, underscore, dash, dot), but the above checks are the minimum required.

**Required changes:**
- In `saveContentToTemp`, add validation for the `name` parameter to reject any value containing "..", "/", or "\\".
- If the validation fails, throw an `IllegalArgumentException` or handle the error appropriately.
- No new imports are required, as this can be done with standard Java string methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
